### PR TITLE
Redirect to townscript instead of a popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,21 @@ active: home
         <br/>
 
         <div class="text-center mar-top-20">
+        
+         <a
+            target="_blank"
+            href="https://www.townscript.com/e/pysangamam2018/booking">
+           Buy Tickets
+         </a>
+        
+          <!--
           <a
             onclick="popup('pysangamam2018');"
             class="tsbutton btn btn-lg btn-outline-primary btn-cfp mar-top-10">
             Buy Tickets
           </a>
+          -->
+          
           <a target="_blank" href="https://cfp.pysangamam.org/" class="btn btn-lg btn-outline-primary btn-cfp mar-top-10">Submit a Proposal</a>
         </div>
       </div>


### PR DESCRIPTION
There seems to be some 405 errors coming up when people are trying to book. For now, we're fixing this by not opting for a popup and redirecting to the website instead