### PR TITLE
Fix focus state on buy / cfp button

### DIFF
--- a/css/pysangamam.css
+++ b/css/pysangamam.css
@@ -139,7 +139,7 @@ a.btn-cfp.tsbutton {
   min-width: 195px;
 }
 
-a.btn-cfp.tsbutton:hover {
+a.btn-cfp.tsbutton:hover, a.btn-cfp.tsbutton:focus {
   border-width: 1px;
   color: white;
   text-transform: none;


### PR DESCRIPTION
As reported by @gnurenga, the focus state was leaving the button highlighted but the text invisible. This sets focus and hover with the same CSS